### PR TITLE
Fix a typo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pandas==0.24.2
 plotly==4.5.0
 python_igraph
 scikit-learn==0.23.2
-psutils
+psutil
 requests


### PR DESCRIPTION
Hello, when reproducing the experiments, I cannot find a Python package named "psutils" but only find "psutil". Is this a typo?